### PR TITLE
Create skillUI enum to consolidate ShadeIcon helpers

### DIFF
--- a/Assets/Prefabs/Player UI Berserker.prefab
+++ b/Assets/Prefabs/Player UI Berserker.prefab
@@ -7,6 +7,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 392239452910451674, guid: 59e742994bac0374a90d4fc778eaf993, type: 3}
+      propertyPath: skillIconUI.Array.size
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2811404963251989149, guid: 59e742994bac0374a90d4fc778eaf993, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0

--- a/Assets/Prefabs/Player UI Support.prefab
+++ b/Assets/Prefabs/Player UI Support.prefab
@@ -7,6 +7,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 392239452910451674, guid: 59e742994bac0374a90d4fc778eaf993, type: 3}
+      propertyPath: skillIconUI.Array.size
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4100136559270405661, guid: 59e742994bac0374a90d4fc778eaf993, type: 3}
       propertyPath: m_Name
       value: Player UI Support

--- a/Assets/Prefabs/Player UI Tank.prefab
+++ b/Assets/Prefabs/Player UI Tank.prefab
@@ -7,6 +7,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 392239452910451674, guid: 59e742994bac0374a90d4fc778eaf993, type: 3}
+      propertyPath: skillIconUI.Array.size
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4100136559270405661, guid: 59e742994bac0374a90d4fc778eaf993, type: 3}
       propertyPath: m_Name
       value: Player UI Tank

--- a/Assets/Prefabs/Player UI.prefab
+++ b/Assets/Prefabs/Player UI.prefab
@@ -28,6 +28,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5945232499836000904}
   m_Father: {fileID: 3955214575862314171}
@@ -104,6 +105,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5763198050215163700}
   m_RootOrder: 0
@@ -179,6 +181,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1834817820614231371}
   m_RootOrder: 0
@@ -253,6 +256,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.425, y: 0.425, z: 0.425}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5168777994895209262}
   - {fileID: 1834817820614231371}
@@ -344,6 +348,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5438728763568767941}
   m_RootOrder: 0
@@ -417,6 +422,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2811404963251989149}
   m_Father: {fileID: 7015075791364429069}
@@ -455,6 +461,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6290963164261258998}
   m_RootOrder: 0
@@ -528,6 +535,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9184525513183754274}
   m_Father: {fileID: 3120772175805062382}
@@ -566,6 +574,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 116192938241318373}
   - {fileID: 6554271154286661446}
@@ -608,9 +617,10 @@ MonoBehaviour:
   screenOffset: {x: 0, y: 30, z: 0}
   playerNameText: {fileID: 8282724548103382448}
   playerHealthSlider: {fileID: 7824473665246855308}
-  primarySkillUI: {fileID: 7381735519919730459}
-  secondarySkillUI: {fileID: 1927623324245940616}
-  ultimateSkillUI: {fileID: 6728830261226378882}
+  skillUI:
+  - {fileID: 7381735519919730459}
+  - {fileID: 1927623324245940616}
+  - {fileID: 6728830261226378882}
 --- !u!1 &4554309861484407828
 GameObject:
   m_ObjectHideFlags: 0
@@ -639,6 +649,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2.358772, y: 2.358772, z: 2.358772}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3120772175805062382}
   m_RootOrder: 2
@@ -714,6 +725,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2.389269, y: 2.389269, z: 2.389269}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5763198050215163700}
   m_RootOrder: 2
@@ -789,6 +801,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3120772175805062382}
   m_RootOrder: 0
@@ -864,6 +877,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2878401870127181729}
   m_RootOrder: 0
@@ -939,6 +953,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2.6087706, y: 2.6087706, z: 2.6087706}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7015075791364429069}
   m_RootOrder: 2
@@ -1014,6 +1029,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7015075791364429069}
   m_RootOrder: 0
@@ -1087,6 +1103,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8219866135132743667}
   m_Father: {fileID: 5763198050215163700}
@@ -1124,6 +1141,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.64, y: 0.64, z: 0.64}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5496053021549520335}
   - {fileID: 2878401870127181729}
@@ -1215,6 +1233,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2.3490047, y: 2.3490047, z: 2.3490047}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3955214575862314171}
   m_RootOrder: 2
@@ -1290,6 +1309,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9130008962266692010}
   m_RootOrder: 0
@@ -1364,6 +1384,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.45, y: 0.45, z: 0.45}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4932160358703992302}
   - {fileID: 9130008962266692010}
@@ -1454,6 +1475,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.88, y: 0.88, z: 0.88}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5438728763568767941}
   - {fileID: 6290963164261258998}
@@ -1543,6 +1565,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5198299106448591572}
   m_Father: {fileID: 3955214575862314171}
@@ -1581,6 +1604,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4688564025219500833}
   m_RootOrder: 0
@@ -1656,6 +1680,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4688564025219500833}
   m_RootOrder: 1

--- a/Assets/Scripts/Player Scripts/BerserkerSkills.cs
+++ b/Assets/Scripts/Player Scripts/BerserkerSkills.cs
@@ -143,7 +143,7 @@ public class BerserkerSkills : MonoBehaviourPun, IPlayerSkills
 
         if (photonView.IsMine)
         {
-            playerUI.UnshadeSkillIcon();
+            playerUI.UnshadeIcon(SkillUI.SECONDARY);
         }
     }
 
@@ -153,7 +153,7 @@ public class BerserkerSkills : MonoBehaviourPun, IPlayerSkills
 
         if (photonView.IsMine)
         {
-            playerUI.UnshadeUltimateIcon();
+            playerUI.UnshadeIcon(SkillUI.ULTIMATE);
         }
     }
     #endregion

--- a/Assets/Scripts/Player Scripts/PlayerActionCore.cs
+++ b/Assets/Scripts/Player Scripts/PlayerActionCore.cs
@@ -82,7 +82,7 @@ public class PlayerActionCore : MonoBehaviourPun
 
                 if (photonView.IsMine)
                 {
-                    playerUI.ShadeBasicAttackIcon();
+                    playerUI.ShadeIcon(SkillUI.PRIMARY);
                 }
 
                 this.ActivateBasicAttack();
@@ -94,7 +94,7 @@ public class PlayerActionCore : MonoBehaviourPun
 
                 if (photonView.IsMine)
                 {
-                    playerUI.ShadeSkillIcon();
+                    playerUI.ShadeIcon(SkillUI.SECONDARY);
                 }
 
                 skills.ActivateSkill();
@@ -106,7 +106,7 @@ public class PlayerActionCore : MonoBehaviourPun
 
                 if (photonView.IsMine)
                 {
-                    playerUI.ShadeUltimateIcon();
+                    playerUI.ShadeIcon(SkillUI.ULTIMATE);
                 }
 
                 skills.ActivateUltimate();
@@ -207,7 +207,7 @@ public class PlayerActionCore : MonoBehaviourPun
 
         if (photonView.IsMine)
         {
-            playerUI.UnshadeBasicAttackIcon();
+            playerUI.UnshadeIcon(SkillUI.PRIMARY);
         }
 
         this.immobile = false;

--- a/Assets/Scripts/Player Scripts/PlayerUI.cs
+++ b/Assets/Scripts/Player Scripts/PlayerUI.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
+public enum SkillUI { PRIMARY, SECONDARY, ULTIMATE }
+
 public class PlayerUI : MonoBehaviour
 {
+
     #region Private Fields
 
     [Tooltip("Pixel offset  from the player target")]
@@ -20,11 +23,7 @@ public class PlayerUI : MonoBehaviour
     private Slider playerHealthSlider;
 
     [SerializeField]
-    private GameObject primarySkillUI;
-    [SerializeField]
-    private GameObject secondarySkillUI;
-    [SerializeField]
-    private GameObject ultimateSkillUI;
+    private GameObject[] skillUI;
 
     private PlayerManagerCore target;
 
@@ -108,66 +107,38 @@ public class PlayerUI : MonoBehaviour
     }
 
     /* Darken the attack icon for feedback while attacking. */
-    public void ShadeBasicAttackIcon()
-    {
-        /* Get the "Outer ring" object, which represents the attack icon */
-        GameObject primarySkillIcon = primarySkillUI.transform.GetChild(0).gameObject;
-        primarySkillIcon.GetComponent<Image>().color = primarySkillIcon.GetComponent<Image>().color * new Color(0.5f, 0.5f, 0.5f);
+    public void ShadeIcon(SkillUI skill) {
+         /* Get the "Outer ring" object, which represents the attack icon */
+        GameObject icon = skillUI[(int)skill].transform.GetChild(0).gameObject;
+        icon.GetComponent<Image>().color = icon.GetComponent<Image>().color * new Color(0.5f, 0.5f, 0.5f);
     }
 
-    public void UnshadeBasicAttackIcon()
-    {
-        /* Get the "Outer ring" object, which represents the attack icon */
-        GameObject primarySkillIcon = primarySkillUI.transform.GetChild(0).gameObject;
-        primarySkillIcon.GetComponent<Image>().color = primarySkillIcon.GetComponent<Image>().color * new Color(2f, 2f, 2f);
-    }
-
-    public void ShadeSkillIcon()
-    {
-        /* Get the "Outer ring" object, which represents the attack icon */
-        GameObject secondarySkillIcon = secondarySkillUI.transform.GetChild(0).gameObject;
-        secondarySkillIcon.GetComponent<Image>().color = secondarySkillIcon.GetComponent<Image>().color * new Color(0.5f, 0.5f, 0.5f);
-    }
-
-    public void UnshadeSkillIcon()
-    {
-        /* Get the "Outer ring" object, which represents the attack icon */
-        GameObject secondarySkillIcon = secondarySkillUI.transform.GetChild(0).gameObject;
-        secondarySkillIcon.GetComponent<Image>().color = secondarySkillIcon.GetComponent<Image>().color * new Color(2f, 2f, 2f);
-    }
-    public void ShadeUltimateIcon()
-    {
-        /* Get the "Outer ring" object, which represents the attack icon */
-        GameObject ultimateSkillIcon = ultimateSkillUI.transform.GetChild(0).gameObject;
-        ultimateSkillIcon.GetComponent<Image>().color = ultimateSkillIcon.GetComponent<Image>().color * new Color(0.5f, 0.5f, 0.5f);
-    }
-
-    public void UnshadeUltimateIcon()
-    {
-        /* Get the "Outer ring" object, which represents the attack icon */
-        GameObject ultimateSkillIcon = ultimateSkillUI.transform.GetChild(0).gameObject;
-        ultimateSkillIcon.GetComponent<Image>().color = ultimateSkillIcon.GetComponent<Image>().color * new Color(2f, 2f, 2f);
+    public void UnshadeIcon(SkillUI skill) {
+         /* Get the "Outer ring" object, which represents the attack icon */
+        GameObject icon = skillUI[(int)skill].transform.GetChild(0).gameObject;
+        icon.GetComponent<Image>().color = icon.GetComponent<Image>().color * new Color(2f, 2f, 2f);
     }
 
     public void UpdateElement()
     {
         // Display the element enhancing player
-        if (primarySkillUI != null)
-        {
-            switch (target.GetElement())
-            {
-                case Element.Fire:
-                    primarySkillUI.transform.GetChild(0).gameObject.GetComponent<Image>().color = Color.red;
-                    break;
-                case Element.Water:
-                    primarySkillUI.transform.GetChild(0).gameObject.GetComponent<Image>().color = Color.blue;
-                    break;
-                case Element.Earth:
-                    primarySkillUI.transform.GetChild(0).gameObject.GetComponent<Image>().color = Color.yellow;
-                    break;
-                default:
-                    primarySkillUI.transform.GetChild(0).gameObject.GetComponent<Image>().color = Color.white;
-                    break;
+        foreach(GameObject icon in skillUI) {
+            if(icon != null) {
+                switch (target.GetElement())
+                {
+                    case Element.Fire:
+                        icon.transform.GetChild(0).gameObject.GetComponent<Image>().color = Color.red;
+                        break;
+                    case Element.Water:
+                        icon.transform.GetChild(0).gameObject.GetComponent<Image>().color = Color.blue;
+                        break;
+                    case Element.Earth:
+                        icon.transform.GetChild(0).gameObject.GetComponent<Image>().color = Color.yellow;
+                        break;
+                    default:
+                        icon.transform.GetChild(0).gameObject.GetComponent<Image>().color = Color.white;
+                        break;
+                }
             }
         }
     }

--- a/Assets/Scripts/Player Scripts/SupportSkills.cs
+++ b/Assets/Scripts/Player Scripts/SupportSkills.cs
@@ -100,7 +100,7 @@ public class SupportSkills : MonoBehaviourPun, IPlayerSkills
 
         if (photonView.IsMine)
         {
-            playerUI.UnshadeUltimateIcon();
+            playerUI.UnshadeIcon(SkillUI.ULTIMATE);
         }
 
         this.gameObject.GetComponent<PlayerActionCore>().setImmobile(false);

--- a/Assets/Scripts/Player Scripts/TankSkills.cs
+++ b/Assets/Scripts/Player Scripts/TankSkills.cs
@@ -61,7 +61,7 @@ public class TankSkills : MonoBehaviourPunCallbacks, IPlayerSkills
 
         if (photonView.IsMine)
         {
-            playerUI.UnshadeSkillIcon();
+            playerUI.UnshadeIcon(SkillUI.SECONDARY);
         }
 
         this.gameObject.GetComponent<PlayerActionCore>().setImmobile(false);
@@ -73,7 +73,7 @@ public class TankSkills : MonoBehaviourPunCallbacks, IPlayerSkills
 
         if (photonView.IsMine)
         {
-            playerUI.UnshadeUltimateIcon();
+            playerUI.UnshadeIcon(SkillUI.ULTIMATE);
         }
 
         this.gameObject.GetComponent<PlayerActionCore>().setImmobile(false);


### PR DESCRIPTION
Organizes the player skill icons into an array, alongside an enum for accessing items of this array.

Doesn't make a difference in terms of behavior, but 
- Looks more compact when we have just one ShadeIcon() and UnshadeIcon() helper
- Makes it easier to iterate the skill icons. If I recall correctly, elemental abilities might be a thing (?) and we're changing the color of the icons based on the element. In that case, it'd be nice to iterate and apply changes to icons in bulk