### PR TITLE
Refactor Animation Events for Healer

### DIFF
--- a/Assets/Animations/Healer/Healer ShieldEnd.anim
+++ b/Assets/Animations/Healer/Healer ShieldEnd.anim
@@ -23148,7 +23148,7 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 1.2666667
-    functionName: FinishSecondarySkill
+    functionName: FinishSecondarySkillAnimation
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Animations/Healer/Healer Shock.anim
+++ b/Assets/Animations/Healer/Healer Shock.anim
@@ -45072,7 +45072,7 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0.93333334
-    functionName: FinishUltimate
+    functionName: FinishUltimateAnimation
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Resources/Healer.prefab
+++ b/Assets/Resources/Healer.prefab
@@ -442,6 +442,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bcb4cc90d23caa643a8b63ca274fe997, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  secondarySkillClips:
+  - {fileID: 7400000, guid: 37f0dc01443c2644ab68205770c9c789, type: 2}
+  - {fileID: 7400000, guid: 91e0d82ef1a900649b2492bc0c89756b, type: 2}
+  ultimateClip: {fileID: 7400000, guid: fe0ffc9f3b1314446bb98cd0eac3c7a5, type: 2}
 --- !u!114 &5495911065371474050
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player Scripts/HealerSkills.cs
+++ b/Assets/Scripts/Player Scripts/HealerSkills.cs
@@ -15,6 +15,15 @@ public class HealerSkills : MonoBehaviourPun, IPlayerSkills
     private PlayerUI playerUI;
 
     private Animator animator;
+    private PlayerActionCore actionCoreScript;
+
+    #region Animation variables
+    // Used to tell how long the secondary/ultimate skills take
+    [SerializeField]
+    private AnimationClip[] secondarySkillClips;
+    [SerializeField]
+    private AnimationClip ultimateClip;
+    #endregion
 
     #endregion
 
@@ -31,6 +40,20 @@ public class HealerSkills : MonoBehaviourPun, IPlayerSkills
         if (!animator)
         {
             Debug.LogError("HealerSkills is Missing Animator Component", this);
+        }
+
+        actionCoreScript = GetComponent<PlayerActionCore>();
+        if (!actionCoreScript)
+        {
+            Debug.LogError("HealerSkills is Missing PlayerActionCore.cs");
+        }
+        if (secondarySkillClips.Length == 0)
+        {
+            Debug.LogError("HealerSkills is Missing Secondary Skill Animation Clip");
+        }
+        if (!ultimateClip)
+        {
+            Debug.LogError("HealerSkills is Missing Ultimate Animation Clip");
         }
     }
 
@@ -50,12 +73,21 @@ public class HealerSkills : MonoBehaviourPun, IPlayerSkills
     {
         Debug.Log("Healer secondary skill activated");
         animator.SetBool("isSecondarySkilling", true);
+
+        // Calculate total length of secondary skill
+        float secondarySkillClipLength = 0;
+        foreach (AnimationClip secondarySkillClip in secondarySkillClips) {
+            secondarySkillClipLength += secondarySkillClip.length;
+        }
+        actionCoreScript.Invoke("FinishSecondarySkillLogic", secondarySkillClipLength);
     }
 
     public void ActivateUltimate()
     {
         Debug.Log("AOE heal ability pressed");
         animator.SetBool("isUltimating", true);
+
+        actionCoreScript.Invoke("FinishUltimateLogic", ultimateClip.length);
     }
     #endregion
 

--- a/Assets/Scripts/Player Scripts/PlayerActionCore.cs
+++ b/Assets/Scripts/Player Scripts/PlayerActionCore.cs
@@ -119,6 +119,7 @@ public class PlayerActionCore : MonoBehaviourPun
     }
     #endregion
 
+    #region Public Functions
     /* TODO: more clear method to manipulate moveability? */
     public void setImmobile(bool m)
     {
@@ -130,6 +131,23 @@ public class PlayerActionCore : MonoBehaviourPun
         this.currentElement = element;
         Debug.Log("Changing Element (action): "+element);
     }
+
+    public void FinishSecondarySkillLogic() {
+        if (photonView.IsMine) {
+            playerUI.UnshadeIcon(SkillUI.SECONDARY);
+        }
+
+        this.immobile = false;
+    }
+
+    public void FinishUltimateLogic() {
+        if (photonView.IsMine) {
+            playerUI.UnshadeIcon(SkillUI.ULTIMATE);
+        }
+
+        this.immobile = false;
+    }
+    #endregion
 
     #region Private Functions
     private void ActivateBasicAttack()
@@ -204,7 +222,16 @@ public class PlayerActionCore : MonoBehaviourPun
 
     #region Animation Events
 
-    public void FinishBasicAttack()
+    public void FinishSecondarySkillAnimation()
+    {
+        animator.SetBool("isSecondarySkilling", false);
+    }
+    public void FinishUltimateAnimation() 
+    {
+        animator.SetBool("isUltimating", false);
+    }
+
+    public void FinishBasicAttack() // TODO: Eventually refactor so that this only finishes the animation?
     {
         animator.SetBool("isBasicAttacking", false);
 
@@ -216,7 +243,7 @@ public class PlayerActionCore : MonoBehaviourPun
         this.immobile = false;
     }
 
-    public void FinishSecondarySkill() {
+    public void FinishSecondarySkill() { // TODO: Delete function after all characters using FinishAnimation & FinishLogic
         animator.SetBool("isSecondarySkilling", false);
 
         if (photonView.IsMine) {
@@ -226,7 +253,7 @@ public class PlayerActionCore : MonoBehaviourPun
         this.immobile = false;
     }
 
-    public void FinishUltimate() {
+    public void FinishUltimate() { // TODO: Delete function after all characters using FinishAnimation & FinishLogic
         animator.SetBool("isUltimating", false);
 
         if (photonView.IsMine) {


### PR DESCRIPTION
Animation events now only end the animation for the healer, rather than controlling skill logic.

Using functions FinishSecondarySkillLogic, FinishSecondarySkillAnimation, FinishUltimateLogic, and FinishUltimateAnimation
Added parameters to Healer script for the animation clips so that we can use their length to determine the length of the skill. 

Currently using an array of clips for the secondary skill, as the skill uses multiple animations. This should be tweaked in future, as using 2 of the clips makes the skill not last long enough, but all 3 clips for skill length makes you immobile for too long.