### PR TITLE
Refactor Animation Events for Support

### DIFF
--- a/Assets/Animations/Placeholders/Secondary Skill Placeholder.anim
+++ b/Assets/Animations/Placeholders/Secondary Skill Placeholder.anim
@@ -52,7 +52,7 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0.033333335
-    functionName: FinishSecondarySkill
+    functionName: FinishSecondarySkillAnimation
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Animations/Support/Support Channel Element.anim
+++ b/Assets/Animations/Support/Support Channel Element.anim
@@ -327,17 +327,3 @@ AnimationClip:
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
-  - time: 2.1333334
-    functionName: FinishChannelingElement
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
-  - time: 2.1333334
-    functionName: setMobile
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0

--- a/Assets/Animations/Support/Support Channel Element.anim
+++ b/Assets/Animations/Support/Support Channel Element.anim
@@ -321,7 +321,7 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 1.9666667
-    functionName: FinishUltimate
+    functionName: FinishUltimateAnimation
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Resources/Support.prefab
+++ b/Assets/Resources/Support.prefab
@@ -26333,6 +26333,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e7698fe6fdb6254a8bf6d70141d940f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  secondarySkillClip: {fileID: 7400000, guid: a6d3c047f8514574aa1845d5b48ed02e, type: 2}
+  ultimateClip: {fileID: 7400000, guid: ccc7e02d0ea585a439f06db51f788917, type: 2}
 --- !u!114 &-1217730770703855096
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player Scripts/PlayerActionCore.cs
+++ b/Assets/Scripts/Player Scripts/PlayerActionCore.cs
@@ -119,6 +119,7 @@ public class PlayerActionCore : MonoBehaviourPun
     }
     #endregion
 
+    #region Public Functions
     /* TODO: more clear method to manipulate moveability? */
     public void setImmobile(bool m)
     {
@@ -130,6 +131,23 @@ public class PlayerActionCore : MonoBehaviourPun
         this.currentElement = element;
         Debug.Log("Changing Element (action): "+element);
     }
+
+    public void FinishSecondarySkillLogic() {
+        if (photonView.IsMine) {
+            playerUI.UnshadeIcon(SkillUI.SECONDARY);
+        }
+
+        this.immobile = false;
+    }
+
+    public void FinishUltimateLogic() {
+        if (photonView.IsMine) {
+            playerUI.UnshadeIcon(SkillUI.ULTIMATE);
+        }
+
+        this.immobile = false;
+    }
+    #endregion
 
     #region Private Functions
     private void ActivateBasicAttack()
@@ -204,7 +222,16 @@ public class PlayerActionCore : MonoBehaviourPun
 
     #region Animation Events
 
-    public void FinishBasicAttack()
+    public void FinishSecondarySkillAnimation()
+    {
+        animator.SetBool("isSecondarySkilling", false);
+    }
+    public void FinishUltimateAnimation() 
+    {
+        animator.SetBool("isUltimating", false);
+    }
+
+    public void FinishBasicAttack() // TODO: Eventually refactor so that this only finishes the animation?
     {
         animator.SetBool("isBasicAttacking", false);
 
@@ -216,7 +243,7 @@ public class PlayerActionCore : MonoBehaviourPun
         this.immobile = false;
     }
 
-    public void FinishSecondarySkill() {
+    public void FinishSecondarySkill() { // TODO: Delete function after all characters using FinishAnimation & FinishLogic
         animator.SetBool("isSecondarySkilling", false);
 
         if (photonView.IsMine) {
@@ -226,7 +253,7 @@ public class PlayerActionCore : MonoBehaviourPun
         this.immobile = false;
     }
 
-    public void FinishUltimate() {
+    public void FinishUltimate() { // TODO: Delete function after all characters using FinishAnimation & FinishLogic
         animator.SetBool("isUltimating", false);
 
         if (photonView.IsMine) {

--- a/Assets/Scripts/Player Scripts/SupportSkills.cs
+++ b/Assets/Scripts/Player Scripts/SupportSkills.cs
@@ -124,6 +124,7 @@ public class SupportSkills : MonoBehaviourPun, IPlayerSkills
         animator.SetBool("isUltimating", true);
 
         actionCoreScript.Invoke("FinishUltimateLogic", ultimateClip.length);
+        Invoke("FinishChannelingElement", ultimateClip.length);
 
         // mostRecentElement = ElementFunctions.NextElement(mostRecentElement);
         // this.GetComponent<PlayerManagerCore>().SetElement(mostRecentElement);

--- a/Assets/Scripts/Player Scripts/SupportSkills.cs
+++ b/Assets/Scripts/Player Scripts/SupportSkills.cs
@@ -60,21 +60,21 @@ public class SupportSkills : MonoBehaviourPun, IPlayerSkills
         animator = GetComponent<Animator>();
         if (!animator)
         {
-            Debug.LogError("BeserkerSkills is Missing Animator Component", this);
+            Debug.LogError("SupportSkills is Missing Animator Component", this);
         }
 
         actionCoreScript = GetComponent<PlayerActionCore>();
         if (!actionCoreScript)
         {
-            Debug.LogError("TankSkills is Missing PlayerActionCore.cs");
+            Debug.LogError("SupportSkills is Missing PlayerActionCore.cs");
         }
         if (!secondarySkillClip)
         {
-            Debug.LogError("TankSkills is Missing Secondary Skill Animation Clip");
+            Debug.LogError("SupportSkills is Missing Secondary Skill Animation Clip");
         }
         if (!ultimateClip)
         {
-            Debug.LogError("TankSkills is Missing Ultimate Animation Clip");
+            Debug.LogError("SupportSkills is Missing Ultimate Animation Clip");
         }
     }
 

--- a/Assets/Scripts/Player Scripts/SupportSkills.cs
+++ b/Assets/Scripts/Player Scripts/SupportSkills.cs
@@ -15,6 +15,7 @@ public class SupportSkills : MonoBehaviourPun, IPlayerSkills
     private PlayerUI playerUI;
 
     private Animator animator;
+    private PlayerActionCore actionCoreScript;
 
     #region Dash Variables
     private CharacterController controller;
@@ -26,6 +27,14 @@ public class SupportSkills : MonoBehaviourPun, IPlayerSkills
     private float dashTimeMax = 0.1f;
     // Current amount of time spent dashing.
     private float dashTimeCurrent = 0f;
+    #endregion
+
+    #region Animation variables
+    // Used to tell how long the secondary/ultimate skills take
+    [SerializeField]
+    private AnimationClip secondarySkillClip;
+    [SerializeField]
+    private AnimationClip ultimateClip;
     #endregion
 
     private Element mostRecentElement = Element.Fire;
@@ -52,6 +61,20 @@ public class SupportSkills : MonoBehaviourPun, IPlayerSkills
         if (!animator)
         {
             Debug.LogError("BeserkerSkills is Missing Animator Component", this);
+        }
+
+        actionCoreScript = GetComponent<PlayerActionCore>();
+        if (!actionCoreScript)
+        {
+            Debug.LogError("TankSkills is Missing PlayerActionCore.cs");
+        }
+        if (!secondarySkillClip)
+        {
+            Debug.LogError("TankSkills is Missing Secondary Skill Animation Clip");
+        }
+        if (!ultimateClip)
+        {
+            Debug.LogError("TankSkills is Missing Ultimate Animation Clip");
         }
     }
 
@@ -91,12 +114,16 @@ public class SupportSkills : MonoBehaviourPun, IPlayerSkills
         animator.SetBool("isSecondarySkilling", true);
 
         dashDirection = this.transform.forward;
+
+        actionCoreScript.Invoke("FinishSecondarySkillLogic", secondarySkillClip.length);
     }
 
     public void ActivateUltimate()
     {
         Debug.Log("Change element button pressed");
         animator.SetBool("isUltimating", true);
+
+        actionCoreScript.Invoke("FinishUltimateLogic", ultimateClip.length);
 
         // mostRecentElement = ElementFunctions.NextElement(mostRecentElement);
         // this.GetComponent<PlayerManagerCore>().SetElement(mostRecentElement);


### PR DESCRIPTION
Animation events now only end the animation for the support, rather than controlling skill logic.

Use functions FinishSecondarySkillLogic, FinishSecondarySkillAnimation, FinishUltimateLogic, and FinishUltimateAnimation
Added parameters to Support script for the animation clips so that we can use their length to determine the length of the skill. Unused function animation event was deleted, and function for finishing channeling is now also invoked instead of being called through an animation event.